### PR TITLE
Dev/zhenghe3119/mt st support patch 2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/shawnfeng/sutil
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/ZhengHe-MD/agollo v0.0.0-20190709010021-166900f9bd56
+	github.com/ZhengHe-MD/agollo v0.0.0-20190710125726-8aacd739399e
 	github.com/bitly/go-simplejson v0.4.4-0.20140701141959-3378bdcb5ceb
 	github.com/coreos/etcd v3.0.0-beta.0.0.20160712024141-cc26f2c8892e+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/ZhengHe-MD/agollo v0.0.0-20190708133309-acc5196ddef0 h1:cOrzO76bwkbRO
 github.com/ZhengHe-MD/agollo v0.0.0-20190708133309-acc5196ddef0/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
 github.com/ZhengHe-MD/agollo v0.0.0-20190709010021-166900f9bd56 h1:y5QtREe6LiwDv8oGRNp0pag0bfcQocX1JNr4DxDAOZA=
 github.com/ZhengHe-MD/agollo v0.0.0-20190709010021-166900f9bd56/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
+github.com/ZhengHe-MD/agollo v0.0.0-20190710125726-8aacd739399e h1:PNO8OTYRzh16UqTO1cWark6n5H6lThqX3IdBz6hkvno=
+github.com/ZhengHe-MD/agollo v0.0.0-20190710125726-8aacd739399e/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
 github.com/ZhengHe-MD/agollo v2.1.0+incompatible h1:NqugIJRTEPNLBtzg3TkM2rfUnpwNRgkhy0Mhk3yJ0Es=
 github.com/ZhengHe-MD/agollo v2.1.0+incompatible/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/mq/config.go
+++ b/mq/config.go
@@ -138,6 +138,7 @@ func (m *EtcdConfig) ParseKey(ctx context.Context, k string) (*KeyParts, error) 
 }
 
 const defaultApolloNamespace = "infra.mq"
+const apolloConfigSep = "."
 
 type ApolloConfig struct {
 	watchOnce sync.Once
@@ -207,7 +208,7 @@ func (m *ApolloConfig) Watch(ctx context.Context) <-chan *center.ChangeEvent {
 
 func (m *ApolloConfig) ParseKey(ctx context.Context, key string) (*KeyParts, error) {
 	fun := "ApolloConfig.ParseKey-->"
-	parts := strings.Split(key, ".")
+	parts := strings.Split(key, apolloConfigSep)
 	numParts := len(parts)
 	if numParts < 4 {
 		errMsg := fmt.Sprintf("%s invalid key:%s", fun, key)
@@ -216,7 +217,7 @@ func (m *ApolloConfig) ParseKey(ctx context.Context, key string) (*KeyParts, err
 	}
 
 	return &KeyParts{
-		Topic: strings.Join(parts[:numParts-3], "."),
+		Topic: strings.Join(parts[:numParts-3], apolloConfigSep),
 		Group: parts[numParts-3],
 	}, nil
 }
@@ -227,5 +228,5 @@ func (m *ApolloConfig) buildKey(ctx context.Context, topic, item string) string 
 		scontext.GetGroupWithDefault(ctx, defaultGroup),
 		fmt.Sprint(MqTypeKafka),
 		item,
-	}, ".")
+	}, apolloConfigSep)
 }

--- a/mq/examples/main.go
+++ b/mq/examples/main.go
@@ -70,35 +70,5 @@ func main() {
 
 	defer mq.Close()
 
-	time.Sleep(20 * time.Second)
-
-	go func() {
-		var msgs []mq.Message
-		for i := 0; i < 10; i++ {
-			value := &Msg{
-				Id:   1,
-				Body: fmt.Sprintf("%d", i),
-			}
-
-			msgs = append(msgs, mq.Message{
-				Key:   value.Body,
-				Value: value,
-			})
-			err := mq.WriteMsg(ctx, topic, value.Body, value)
-			slog.Infof(ctx, "in msg: %v, err:%v", value, err)
-		}
-		err := mq.WriteMsgs(ctx, topic, msgs...)
-		slog.Infof(ctx, "in msgs: %v, err:%v", msgs, err)
-	}()
-
-	go func() {
-		for i := 0; i < 10000; i++ {
-			var msg Msg
-			ctx1 := context.Background()
-			ctx, err := mq.ReadMsgByGroup(ctx1, topic, "group2", &msg)
-			slog.Infof(ctx, "out msg: %v, ctx:%v, err:%v", msg, ctx, err)
-		}
-	}()
-
-	time.Sleep(20 * time.Second)
+	time.Sleep(3 * time.Second)
 }

--- a/mq/examples/main.go
+++ b/mq/examples/main.go
@@ -36,7 +36,9 @@ func main() {
 
 	center.Init(ctx, "test/test", []string{"application", "infra.mq"})
 
-	mq.SetConfiger(mq.NewApolloConfig())
+	configer, _ := mq.NewConfiger(mq.ConfigTypeApollo)
+	mq.SetConfiger(configer)
+	mq.WatchUpdate(ctx)
 
 	go func() {
 		var msgs []mq.Message
@@ -68,5 +70,35 @@ func main() {
 
 	defer mq.Close()
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(20 * time.Second)
+
+	go func() {
+		var msgs []mq.Message
+		for i := 0; i < 10; i++ {
+			value := &Msg{
+				Id:   1,
+				Body: fmt.Sprintf("%d", i),
+			}
+
+			msgs = append(msgs, mq.Message{
+				Key:   value.Body,
+				Value: value,
+			})
+			err := mq.WriteMsg(ctx, topic, value.Body, value)
+			slog.Infof(ctx, "in msg: %v, err:%v", value, err)
+		}
+		err := mq.WriteMsgs(ctx, topic, msgs...)
+		slog.Infof(ctx, "in msgs: %v, err:%v", msgs, err)
+	}()
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			var msg Msg
+			ctx1 := context.Background()
+			ctx, err := mq.ReadMsgByGroup(ctx1, topic, "group2", &msg)
+			slog.Infof(ctx, "out msg: %v, ctx:%v, err:%v", msg, ctx, err)
+		}
+	}()
+
+	time.Sleep(20 * time.Second)
 }

--- a/mq/instance.go
+++ b/mq/instance.go
@@ -6,19 +6,90 @@ package mq
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/shawnfeng/sutil/scontext"
 	"github.com/shawnfeng/sutil/slog/slog"
+	"strconv"
 	"strings"
 	"sync"
 )
 
 var DefaultInstanceManager = NewInstanceManager()
 
+type MQRoleType int
+
 const (
-	RoleTypeReader = iota
+	RoleTypeReader MQRoleType = iota
 	RoleTypeWriter
 )
+
+var (
+	InvalidMqRoleTypeStringErr = errors.New("invalid mq role type string")
+)
+
+func (t MQRoleType) String() string {
+	switch t {
+	case RoleTypeReader:
+		return "reader"
+	case RoleTypeWriter:
+		return "writer"
+	}
+	// unreachable
+	return ""
+}
+
+func MQRoleTypeFromInt(it int) (t MQRoleType, err error) {
+	switch it {
+	case 0:
+		t = RoleTypeReader
+	case 1:
+		t = RoleTypeWriter
+	default:
+		err = InvalidMqRoleTypeStringErr
+	}
+	return
+}
+
+type instanceConf struct {
+	group string
+	role MQRoleType
+	topic string
+	groupId string
+	partition int
+}
+
+func (c *instanceConf) String() string {
+	return fmt.Sprintf("%s-%d-%s-%s-%d",
+		c.group, c.role, c.topic, c.groupId, c.partition)
+}
+
+func instanceConfFromString(s string) (conf *instanceConf, err error) {
+	items := strings.Split(s, "-")
+	if len(items) != 5 {
+		return nil, fmt.Errorf("invalid instance conf string:%s", s)
+	}
+
+	conf = &instanceConf{
+		group: items[0],
+		topic: items[2],
+		groupId: items[3],
+	}
+
+	it, err := strconv.Atoi(items[1])
+	if err != nil {
+		return nil, err
+	}
+	conf.role, err = MQRoleTypeFromInt(it)
+	if err != nil {
+		return nil, err
+	}
+
+	conf.partition, err = strconv.Atoi(items[4])
+	if err != nil {
+		return nil, err
+	}
+	return
+}
 
 type InstanceManager struct {
 	instances sync.Map
@@ -28,64 +99,49 @@ func NewInstanceManager() *InstanceManager {
 	return &InstanceManager{}
 }
 
-func (m *InstanceManager) buildKey(flag string, role int, topic, groupId string, partition int) string {
-	return fmt.Sprintf("%s-%d-%s-%s-%d", flag, role, topic, groupId, partition)
+func (m *InstanceManager) buildKey(conf *instanceConf) string {
+	return conf.String()
 }
 
-func (m *InstanceManager) add(flag string, role int, topic, groupId string, partition int, in interface{}) {
-	m.instances.Store(m.buildKey(flag, role, topic, groupId, partition), in)
+func (m *InstanceManager) confFromKey(key string) (*instanceConf, error) {
+	return instanceConfFromString(key)
 }
 
-func (m *InstanceManager) getRole(key string) (int, error) {
-	items := strings.Split(key, "-")
-	if len(items) != 5 {
-		return 0, fmt.Errorf("key error, key:%s", key)
-	}
-
-	if items[1] == "0" {
-		return RoleTypeReader, nil
-	}
-
-	if items[1] == "1" {
-		return RoleTypeWriter, nil
-	}
-
-	return 0, fmt.Errorf("key error, key:%s", key)
+func (m *InstanceManager) add(conf *instanceConf, in interface{}) {
+	m.instances.Store(conf.String(), in)
 }
 
-func (m *InstanceManager) newInstance(ctx context.Context, role int, topic, groupId string, partition int) (interface{}, error) {
+func (m *InstanceManager) newInstance(ctx context.Context, conf *instanceConf) (interface{}, error) {
 
-	switch role {
+	switch conf.role {
 	case RoleTypeReader:
-		if len(groupId) > 0 {
-			return NewGroupReader(ctx, topic, groupId)
+		if len(conf.groupId) > 0 {
+			return NewGroupReader(ctx, conf.topic, conf.groupId)
 		} else {
-			return NewPartitionReader(ctx, topic, partition)
+			return NewPartitionReader(ctx, conf.topic, conf.partition)
 		}
 
 	case RoleTypeWriter:
-		return NewWriter(ctx, topic)
+		return NewWriter(ctx, conf.topic)
 
 	default:
-		return nil, fmt.Errorf("role %d error", role)
+		return nil, fmt.Errorf("role %d error", conf.role)
 	}
 }
 
-func (m *InstanceManager) get(ctx context.Context, role int, topic, groupId string, partition int) interface{} {
+func (m *InstanceManager) get(ctx context.Context, conf *instanceConf) interface{} {
 	fun := "InstanceManager.get -->"
-
-	group := scontext.GetGroup(ctx)
 
 	var err error
 	var in interface{}
-	key := m.buildKey(group, role, topic, groupId, partition)
+	key := m.buildKey(conf)
 	in, ok := m.instances.Load(key)
 	if ok == false {
 
-		slog.Infof(ctx, "%s newInstance, role:%d, topic: %s", fun, role, topic)
-		in, err = m.newInstance(ctx, role, topic, groupId, partition)
+		slog.Infof(ctx, "%s newInstance, role:%v, topic: %s", fun, conf.role, conf.topic)
+		in, err = m.newInstance(ctx, conf)
 		if err != nil {
-			slog.Errorf(ctx, "%s NewInstance err, topic: %s, err: %s", fun, topic, err.Error())
+			slog.Errorf(ctx, "%s NewInstance err, topic: %s, err: %s", fun, conf.topic, err.Error())
 			return nil
 		}
 
@@ -94,34 +150,38 @@ func (m *InstanceManager) get(ctx context.Context, role int, topic, groupId stri
 	return in
 }
 
-func (m *InstanceManager) getReader(ctx context.Context, role int, topic, groupId string, partition int) Reader {
+func (m *InstanceManager) watchInstance(ctx context.Context) {
+
+}
+
+func (m *InstanceManager) getReader(ctx context.Context, conf *instanceConf) Reader {
 	fun := "InstanceManager.getReader -->"
 
-	in := m.get(ctx, role, topic, groupId, partition)
+	in := m.get(ctx, conf)
 	if in == nil {
 		return nil
 	}
 
 	reader, ok := in.(Reader)
 	if ok == false {
-		slog.Errorf(ctx, "%s in.(Reader) err, topic: %s", fun, topic)
+		slog.Errorf(ctx, "%s in.(Reader) err, topic: %s", fun, conf.topic)
 		return nil
 	}
 
 	return reader
 }
 
-func (m *InstanceManager) getWriter(ctx context.Context, role int, topic, groupId string, partition int) Writer {
+func (m *InstanceManager) getWriter(ctx context.Context, conf *instanceConf) Writer {
 	fun := "InstanceManager.getReader -->"
 
-	in := m.get(ctx, role, topic, groupId, partition)
+	in := m.get(ctx, conf)
 	if in == nil {
 		return nil
 	}
 
 	writer, ok := in.(Writer)
 	if ok == false {
-		slog.Errorf(ctx, "%s in.(Writer) err, topic: %s", fun, topic)
+		slog.Errorf(ctx, "%s in.(Writer) err, topic: %s", fun, conf.topic)
 		return nil
 	}
 
@@ -142,13 +202,13 @@ func (m *InstanceManager) Close() {
 			return false
 		}
 
-		role, err := m.getRole(skey)
+		conf, err := m.confFromKey(skey)
 		if err != nil {
 			slog.Errorf(ctx, "%s key:%v, err:%s", fun, key, err)
 			return false
 		}
 
-		if role == RoleTypeReader {
+		if conf.role == RoleTypeReader {
 			reader, ok := value.(Reader)
 			if ok == false {
 				slog.Errorf(ctx, "%s value.(Reader), key:%v", fun, key)
@@ -158,7 +218,7 @@ func (m *InstanceManager) Close() {
 			reader.Close()
 		}
 
-		if role == RoleTypeWriter {
+		if conf.role == RoleTypeWriter {
 			writer, ok := value.(Writer)
 			if ok == false {
 				slog.Errorf(ctx, "%s value.(Writer), key:%v", fun, key)

--- a/mq/interface.go
+++ b/mq/interface.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
+	"github.com/shawnfeng/sutil/scontext"
 	"github.com/shawnfeng/sutil/slog/slog"
 	"github.com/shawnfeng/sutil/stime"
 	"time"
@@ -38,8 +39,14 @@ func WriteMsg(ctx context.Context, topic string, key string, value interface{}) 
 		log.String(spanLogKeyTopic, topic),
 		log.String(spanLogKeyKey, key))
 
-	//todo flag
-	writer := DefaultInstanceManager.getWriter(ctx, RoleTypeWriter, topic, "", 0)
+	conf := &instanceConf{
+		group:     scontext.GetGroup(ctx),
+		role:      RoleTypeWriter,
+		topic:     topic,
+		groupId:   "",
+		partition: 0,
+	}
+	writer := DefaultInstanceManager.getWriter(ctx, conf)
 	if writer == nil {
 		slog.Errorf(ctx, "%s getWriter err, topic: %s", fun, topic)
 		return fmt.Errorf("%s, getWriter err, topic: %s", fun, topic)
@@ -69,8 +76,14 @@ func WriteMsgs(ctx context.Context, topic string, msgs ...Message) error {
 	defer span.Finish()
 	span.LogFields(log.String(spanLogKeyTopic, topic))
 
-	//todo flag
-	writer := DefaultInstanceManager.getWriter(ctx, RoleTypeWriter, topic, "", 0)
+	conf := &instanceConf{
+		group:     scontext.GetGroup(ctx),
+		role:      RoleTypeWriter,
+		topic:     topic,
+		groupId:   "",
+		partition: 0,
+	}
+	writer := DefaultInstanceManager.getWriter(ctx, conf)
 	if writer == nil {
 		slog.Errorf(ctx, "%s getWriter err, topic: %s", fun, topic)
 		return fmt.Errorf("%s, getWriter err, topic: %s", fun, topic)
@@ -103,8 +116,14 @@ func ReadMsgByGroup(ctx context.Context, topic, groupId string, value interface{
 		log.String(spanLogKeyTopic, topic),
 		log.String(spanLogKeyGroupId, groupId))
 
-	//todo flag
-	reader := DefaultInstanceManager.getReader(ctx, RoleTypeReader, topic, groupId, 0)
+	conf := &instanceConf{
+		group:     scontext.GetGroup(ctx),
+		role:      RoleTypeReader,
+		topic:     topic,
+		groupId:   groupId,
+		partition: 0,
+	}
+	reader := DefaultInstanceManager.getReader(ctx, conf)
 	if reader == nil {
 		slog.Errorf(ctx, "%s getReader err, topic: %s", fun, topic)
 		return nil, fmt.Errorf("%s, getReader err, topic: %s", fun, topic)
@@ -151,7 +170,14 @@ func ReadMsgByPartition(ctx context.Context, topic string, partition int, value 
 		log.Int(spanLogKeyPartition, partition))
 
 	//todo flag
-	reader := DefaultInstanceManager.getReader(ctx, RoleTypeReader, topic, "", partition)
+	conf := &instanceConf{
+		group:     scontext.GetGroup(ctx),
+		role:      RoleTypeReader,
+		topic:     topic,
+		groupId:   "",
+		partition: partition,
+	}
+	reader := DefaultInstanceManager.getReader(ctx, conf)
 	if reader == nil {
 		slog.Errorf(ctx, "%s getReader err, topic: %s", fun, topic)
 		return nil, fmt.Errorf("%s, getReader err, topic: %s", fun, topic)
@@ -198,7 +224,14 @@ func FetchMsgByGroup(ctx context.Context, topic, groupId string, value interface
 		log.String(spanLogKeyGroupId, groupId))
 
 	//todo flag
-	reader := DefaultInstanceManager.getReader(ctx, RoleTypeReader, topic, groupId, 0)
+	conf := &instanceConf{
+		group:     scontext.GetGroup(ctx),
+		role:      RoleTypeReader,
+		topic:     topic,
+		groupId:   groupId,
+		partition: 0,
+	}
+	reader := DefaultInstanceManager.getReader(ctx, conf)
 	if reader == nil {
 		slog.Errorf(ctx, "%s getReader err, topic: %s", fun, topic)
 		return nil, nil, fmt.Errorf("%s, getReader err, topic: %s", fun, topic)

--- a/mq/interface.go
+++ b/mq/interface.go
@@ -21,6 +21,8 @@ const (
 	spanLogKeyTopic     = "topic"
 	spanLogKeyGroupId   = "groupId"
 	spanLogKeyPartition = "partition"
+
+	defaultGroup = "default"
 )
 
 var mqOpDurationLimit = 10 * time.Millisecond
@@ -40,7 +42,7 @@ func WriteMsg(ctx context.Context, topic string, key string, value interface{}) 
 		log.String(spanLogKeyKey, key))
 
 	conf := &instanceConf{
-		group:     scontext.GetGroup(ctx),
+		group:     scontext.GetGroupWithDefault(ctx, defaultGroup),
 		role:      RoleTypeWriter,
 		topic:     topic,
 		groupId:   "",
@@ -77,7 +79,7 @@ func WriteMsgs(ctx context.Context, topic string, msgs ...Message) error {
 	span.LogFields(log.String(spanLogKeyTopic, topic))
 
 	conf := &instanceConf{
-		group:     scontext.GetGroup(ctx),
+		group:     scontext.GetGroupWithDefault(ctx, defaultGroup),
 		role:      RoleTypeWriter,
 		topic:     topic,
 		groupId:   "",
@@ -117,7 +119,7 @@ func ReadMsgByGroup(ctx context.Context, topic, groupId string, value interface{
 		log.String(spanLogKeyGroupId, groupId))
 
 	conf := &instanceConf{
-		group:     scontext.GetGroup(ctx),
+		group:     scontext.GetGroupWithDefault(ctx, defaultGroup),
 		role:      RoleTypeReader,
 		topic:     topic,
 		groupId:   groupId,
@@ -171,7 +173,7 @@ func ReadMsgByPartition(ctx context.Context, topic string, partition int, value 
 
 	//todo flag
 	conf := &instanceConf{
-		group:     scontext.GetGroup(ctx),
+		group:     scontext.GetGroupWithDefault(ctx, defaultGroup),
 		role:      RoleTypeReader,
 		topic:     topic,
 		groupId:   "",
@@ -225,7 +227,7 @@ func FetchMsgByGroup(ctx context.Context, topic, groupId string, value interface
 
 	//todo flag
 	conf := &instanceConf{
-		group:     scontext.GetGroup(ctx),
+		group:     scontext.GetGroupWithDefault(ctx, defaultGroup),
 		role:      RoleTypeReader,
 		topic:     topic,
 		groupId:   groupId,
@@ -269,6 +271,10 @@ func FetchMsgByGroup(ctx context.Context, topic, groupId string, value interface
 
 func SetConfiger(configer Configer) {
 	DefaultConfiger = configer
+}
+
+func WatchUpdate(ctx context.Context) {
+	go DefaultInstanceManager.watch(ctx)
 }
 
 func Close() {

--- a/mq/interface.go
+++ b/mq/interface.go
@@ -171,7 +171,6 @@ func ReadMsgByPartition(ctx context.Context, topic string, partition int, value 
 		log.String(spanLogKeyTopic, topic),
 		log.Int(spanLogKeyPartition, partition))
 
-	//todo flag
 	conf := &instanceConf{
 		group:     scontext.GetGroupWithDefault(ctx, defaultGroup),
 		role:      RoleTypeReader,
@@ -225,7 +224,6 @@ func FetchMsgByGroup(ctx context.Context, topic, groupId string, value interface
 		log.String(spanLogKeyTopic, topic),
 		log.String(spanLogKeyGroupId, groupId))
 
-	//todo flag
 	conf := &instanceConf{
 		group:     scontext.GetGroupWithDefault(ctx, defaultGroup),
 		role:      RoleTypeReader,

--- a/mq/reader.go
+++ b/mq/reader.go
@@ -7,9 +7,6 @@ package mq
 import (
 	"context"
 	"fmt"
-	//"time"
-	// kafka "github.com/segmentio/kafka-go"
-	//"github.com/shawnfeng/sutil/slog/slog"
 )
 
 type Handler interface {
@@ -25,7 +22,10 @@ type Reader interface {
 //CommitInterval indicates the interval at which offsets are committed to
 // the broker.  If 0, commits will be handled synchronously.
 func NewGroupReader(ctx context.Context, topic, groupId string) (Reader, error) {
-	config := DefaultConfiger.GetConfig(ctx, topic)
+	config, err := DefaultConfiger.GetConfig(ctx, topic)
+	if err != nil {
+		return nil, err
+	}
 
 	mqType := config.MQType
 	switch mqType {
@@ -43,7 +43,10 @@ const (
 )
 
 func NewPartitionReader(ctx context.Context, topic string, partition int) (Reader, error) {
-	config := DefaultConfiger.GetConfig(ctx, topic)
+	config, err := DefaultConfiger.GetConfig(ctx, topic)
+	if err != nil {
+		return nil, err
+	}
 
 	offset := config.Offset
 	mqType := config.MQType

--- a/mq/writer.go
+++ b/mq/writer.go
@@ -7,8 +7,6 @@ package mq
 import (
 	"context"
 	"fmt"
-	// kafka "github.com/segmentio/kafka-go"
-	//"github.com/shawnfeng/sutil/slog/slog"
 )
 
 type Writer interface {
@@ -18,7 +16,10 @@ type Writer interface {
 }
 
 func NewWriter(ctx context.Context, topic string) (Writer, error) {
-	config := DefaultConfiger.GetConfig(ctx, topic)
+	config, err := DefaultConfiger.GetConfig(ctx, topic)
+	if err != nil {
+		return nil, err
+	}
 
 	mqType := config.MQType
 	switch mqType {

--- a/sconf/center/change.go
+++ b/sconf/center/change.go
@@ -13,6 +13,13 @@ const (
 	DELETE
 )
 
+type ChangeEventSource int
+
+const (
+	Etcd ChangeEventSource = iota
+	Apollo
+)
+
 var (
 	invalidAgolloChangeTypeErr = errors.New("invalid agollo change type")
 )
@@ -31,14 +38,12 @@ func (c ChangeType) String() string {
 }
 
 type ChangeEvent struct {
+	Source ChangeEventSource
+	// Namespace means
+	//   Namespace in Apollo
+	//   Path in Etcd
 	Namespace string
 	Changes   map[string]*Change
-}
-
-type Change struct {
-	OldValue   string
-	NewValue   string
-	ChangeType ChangeType
 }
 
 func fromAgolloChangeEvent(ace *agollo.ChangeEvent) *ChangeEvent {
@@ -49,9 +54,16 @@ func fromAgolloChangeEvent(ace *agollo.ChangeEvent) *ChangeEvent {
 		}
 	}
 	return &ChangeEvent{
+		Source:    Apollo,
 		Namespace: ace.Namespace,
 		Changes:   changes,
 	}
+}
+
+type Change struct {
+	OldValue   string
+	NewValue   string
+	ChangeType ChangeType
 }
 
 func fromAgolloChange(ac *agollo.Change) (change *Change, err error) {

--- a/scontext/scontext.go
+++ b/scontext/scontext.go
@@ -39,3 +39,10 @@ func GetGroup(ctx context.Context) string {
 
 	return control.GetGroup()
 }
+
+func GetGroupWithDefault(ctx context.Context, dv string) string {
+	if group := GetGroup(ctx); group != "" {
+		return group
+	}
+	return dv
+}


### PR DESCRIPTION
1. 更新 apollo client 包
2. 修改 Configer 接口
    * GetConfig 返回值增加 err
    * ParseKey 支持从 ChangeEvent 中解析出发生变化的配置主体
    * Watch 支持动态更新
3. sconf/center 接口修改，从直接暴露 channel 改成 observer pattern，支持多个线程消费同一个事件
4. instanceManager 支持监听配置平台的通知事件，并更新 instance