### PR TITLE
centualize middleware configs

### DIFF
--- a/cache/redis/config.go
+++ b/cache/redis/config.go
@@ -132,7 +132,6 @@ func (m *EtcdConfig) Watch(ctx context.Context) <-chan *center.ChangeEvent {
 }
 
 const (
-	defaultApolloNamespace = "infra.cache"
 	apolloConfigSep        = "."
 
 	apolloConfigKeyAddr     = "addr"
@@ -153,9 +152,9 @@ func NewApolloConfiger() *ApolloConfig {
 
 func (m *ApolloConfig) Init(ctx context.Context) error {
 	fun := "ApolloConfig.Init-->"
-	err := center.SubscribeNamespaces(ctx, []string{defaultApolloNamespace})
+	err := center.Init(ctx, center.DefaultApolloMiddlewareService, []string{center.DefaultApolloCacheNamespace})
 	if err != nil {
-		slog.Errorf(ctx, "%s subscribe namespace:%s err:%v", fun, defaultApolloNamespace, err)
+		slog.Errorf(ctx, "%s init config center err:%v", fun, err)
 	}
 	return err
 }
@@ -169,19 +168,19 @@ func (s simpleContextController) GetGroup() string {
 }
 
 func (m *ApolloConfig) getConfigStringItemWithFallback(ctx context.Context, namespace, name string) (string, bool) {
-	val, ok := center.GetStringWithNamespace(ctx, defaultApolloNamespace, m.buildKey(ctx, namespace, name))
+	val, ok := center.GetStringWithNamespace(ctx, center.DefaultApolloCacheNamespace, m.buildKey(ctx, namespace, name))
 	if !ok {
 		defaultCtx := context.WithValue(ctx, scontext.ContextKeyControl, simpleContextController{defaultGroup})
-		val, ok = center.GetStringWithNamespace(defaultCtx, defaultApolloNamespace, m.buildKey(defaultCtx, namespace, name))
+		val, ok = center.GetStringWithNamespace(defaultCtx, center.DefaultApolloCacheNamespace, m.buildKey(defaultCtx, namespace, name))
 	}
 	return val, ok
 }
 
 func (m *ApolloConfig) getConfigIntItemWithFallback(ctx context.Context, namespace, name string) (int, bool) {
-	val, ok := center.GetIntWithNamespace(ctx, defaultApolloNamespace, m.buildKey(ctx, namespace, name))
+	val, ok := center.GetIntWithNamespace(ctx, center.DefaultApolloCacheNamespace, m.buildKey(ctx, namespace, name))
 	if !ok {
 		defaultCtx := context.WithValue(ctx, scontext.ContextKeyControl, simpleContextController{defaultGroup})
-		val, ok = center.GetIntWithNamespace(defaultCtx, defaultApolloNamespace, m.buildKey(defaultCtx, namespace, name))
+		val, ok = center.GetIntWithNamespace(defaultCtx, center.DefaultApolloCacheNamespace, m.buildKey(defaultCtx, namespace, name))
 	}
 	return val, ok
 }
@@ -241,7 +240,7 @@ type apolloObserver struct {
 }
 
 func (ob *apolloObserver) HandleChangeEvent(event *center.ChangeEvent) {
-	if event.Namespace != defaultApolloNamespace {
+	if event.Namespace != center.DefaultApolloCacheNamespace {
 		return
 	}
 

--- a/cache/value/value.go
+++ b/cache/value/value.go
@@ -18,7 +18,6 @@ import (
 	"github.com/shawnfeng/sutil/cache/redis"
 	"github.com/shawnfeng/sutil/scontext"
 	"github.com/shawnfeng/sutil/slog/slog"
-	"strings"
 	"time"
 )
 
@@ -34,7 +33,7 @@ type Cache struct {
 
 func NewCache(namespace, prefix string, expire time.Duration, load LoadFunc) *Cache {
 	return &Cache{
-		namespace: strings.Replace(namespace, "/", ".", -1),
+		namespace: namespace,
 		prefix:    prefix,
 		load:      load,
 		expire:    expire,

--- a/cache/value/value_test.go
+++ b/cache/value/value_test.go
@@ -3,7 +3,6 @@ package value
 import (
 	"context"
 	cache2 "github.com/shawnfeng/sutil/cache"
-	"github.com/shawnfeng/sutil/sconf/center"
 	"github.com/shawnfeng/sutil/trace"
 
 	//"fmt"
@@ -27,7 +26,6 @@ func load(key interface{}) (value interface{}, err error) {
 func TestGet(t *testing.T) {
 	ctx := context.Background()
 	_ = trace.InitDefaultTracer("cache.test")
-	_ = center.Init(ctx, "base/report", []string{"application", "infra.cache"})
 
 	cache := NewCache("base/report", "test", 60*time.Second, load)
 	_ = SetConfiger(ctx, cache2.ConfigerTypeApollo)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/shawnfeng/sutil
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/ZhengHe-MD/agollo v0.0.0-20190715132943-c90b067b2672
+	github.com/ZhengHe-MD/agollo v0.0.0-20190716115826-871879c67d2c
 	github.com/bitly/go-simplejson v0.4.4-0.20140701141959-3378bdcb5ceb
 	github.com/coreos/etcd v3.0.0-beta.0.0.20160712024141-cc26f2c8892e+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/ZhengHe-MD/agollo v0.0.0-20190711130552-44a6f590a51c h1:PcCai3ucqrNtM
 github.com/ZhengHe-MD/agollo v0.0.0-20190711130552-44a6f590a51c/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
 github.com/ZhengHe-MD/agollo v0.0.0-20190715132943-c90b067b2672 h1:UQCjZh9XU9x/2XKsR7e4eApWx2PDL46Ive86xobpUV8=
 github.com/ZhengHe-MD/agollo v0.0.0-20190715132943-c90b067b2672/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
+github.com/ZhengHe-MD/agollo v0.0.0-20190716115826-871879c67d2c h1:JqNcZdgvS1L0DB/RQ9nHMFHqOoqz6BdF7kAOfWfnMSw=
+github.com/ZhengHe-MD/agollo v0.0.0-20190716115826-871879c67d2c/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
 github.com/ZhengHe-MD/agollo v2.1.0+incompatible h1:NqugIJRTEPNLBtzg3TkM2rfUnpwNRgkhy0Mhk3yJ0Es=
 github.com/ZhengHe-MD/agollo v2.1.0+incompatible/go.mod h1:Hs1VYbuOoVlDPOMlZawvwpN7eAqDOQUFG3Lxcne0SBo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/mq/config_test.go
+++ b/mq/config_test.go
@@ -116,7 +116,8 @@ func TestApolloConfig_getConfigItemWithFallback(t *testing.T) {
 		ctx := context.TODO()
 		conf := NewApolloConfiger()
 
-		brokersVal := conf.getConfigItemWithFallback(ctx, defaultTestTopic, apolloBrokersKey)
+		brokersVal, ok := conf.getConfigItemWithFallback(ctx, defaultTestTopic, apolloBrokersKey)
+		assert.True(t, ok)
 		assert.True(t, len(brokersVal) > 0, "got brokers:", brokersVal)
 		slog.Infof(ctx, "got brokers:%s", brokersVal)
 	})
@@ -127,7 +128,8 @@ func TestApolloConfig_getConfigItemWithFallback(t *testing.T) {
 
 		conf := NewApolloConfiger()
 
-		brokersVal := conf.getConfigItemWithFallback(ctx, defaultTestTopic, apolloBrokersKey)
+		brokersVal, ok := conf.getConfigItemWithFallback(ctx, defaultTestTopic, apolloBrokersKey)
+		assert.True(t, ok)
 		assert.True(t, len(brokersVal) > 0, "got brokers:", brokersVal)
 		slog.Infof(ctx, "got brokers:%s", brokersVal)
 	})
@@ -138,7 +140,8 @@ func TestApolloConfig_getConfigItemWithFallback(t *testing.T) {
 
 		conf := NewApolloConfiger()
 
-		brokersVal := conf.getConfigItemWithFallback(ctx, defaultTestTopic, apolloBrokersKey)
+		brokersVal, ok := conf.getConfigItemWithFallback(ctx, defaultTestTopic, apolloBrokersKey)
+		assert.True(t, ok)
 		assert.True(t, len(brokersVal) > 0, "got brokers:", brokersVal)
 		slog.Infof(ctx, "got brokers:%s", brokersVal)
 	})

--- a/mq/examples/main.go
+++ b/mq/examples/main.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/opentracing/opentracing-go"
 	"github.com/shawnfeng/sutil/mq"
-	"github.com/shawnfeng/sutil/sconf/center"
 	"github.com/shawnfeng/sutil/scontext"
 	"github.com/shawnfeng/sutil/slog/slog"
 	"github.com/shawnfeng/sutil/trace"
@@ -34,7 +33,6 @@ func main() {
 		defer span.Finish()
 	}
 
-	_ = center.Init(ctx, "test/test", nil)
 	_ = mq.SetConfiger(ctx, mq.ConfigerTypeApollo)
 	mq.WatchUpdate(ctx)
 

--- a/mq/instance_test.go
+++ b/mq/instance_test.go
@@ -71,9 +71,8 @@ func getSyncMapSizeUnSafe(m sync.Map) (ret int) {
 
 func TestInstanceManager_applyChangeEvent_apolloConfig(t *testing.T) {
 	ctx := context.TODO()
-	configer, _ := NewConfiger(ConfigerTypeApollo)
-	apolloConfig, _ := configer.(*ApolloConfig)
-	SetConfiger(configer)
+	_ = SetConfiger(ctx, ConfigerTypeApollo)
+	apolloConfig, _ := DefaultConfiger.(*ApolloConfig)
 
 	t.Run("ignore add event", func(t *testing.T) {
 		m := NewInstanceManager()
@@ -88,7 +87,7 @@ func TestInstanceManager_applyChangeEvent_apolloConfig(t *testing.T) {
 
 		ce := &center.ChangeEvent{
 			Source:    center.Apollo,
-			Namespace: defaultApolloNamespace,
+			Namespace: center.DefaultApolloMQNamespace,
 			Changes: map[string]*center.Change{
 				m.buildKey(conf): {
 					NewValue:   "localhost:9092",
@@ -118,7 +117,7 @@ func TestInstanceManager_applyChangeEvent_apolloConfig(t *testing.T) {
 
 		ce := &center.ChangeEvent{
 			Source:    center.Apollo,
-			Namespace: defaultApolloNamespace,
+			Namespace: center.DefaultApolloMQNamespace,
 			Changes: map[string]*center.Change{
 				apolloConfig.buildKey(ctx, defaultTestTopic, "brokers"): {
 					ChangeType: center.MODIFY,
@@ -150,7 +149,7 @@ func TestInstanceManager_applyChangeEvent_apolloConfig(t *testing.T) {
 
 		ce := &center.ChangeEvent{
 			Source:    center.Apollo,
-			Namespace: defaultApolloNamespace,
+			Namespace: center.DefaultApolloMQNamespace,
 			Changes: map[string]*center.Change{
 				apolloConfig.buildKey(ctx, defaultTestTopic, "brokers"): {
 					ChangeType: center.MODIFY,

--- a/sconf/center/constants.go
+++ b/sconf/center/constants.go
@@ -1,0 +1,8 @@
+package center
+
+const (
+	DefaultApolloMiddlewareService = "middleware"
+
+	DefaultApolloMQNamespace = "infra.mq"
+	DefaultApolloCacheNamespace = "infra.cache"
+)

--- a/sconf/center/interface.go
+++ b/sconf/center/interface.go
@@ -2,8 +2,33 @@ package center
 
 import (
 	"context"
-	"github.com/opentracing/opentracing-go"
+	"fmt"
 )
+
+type ConfigCenterType int
+
+const (
+	ApolloConfigCenter ConfigCenterType = iota
+)
+
+func (c ConfigCenterType) String() string {
+	switch c {
+	case ApolloConfigCenter:
+		return "apollo"
+	default:
+		return "unknown"
+	}
+}
+
+func NewConfigCenter(t ConfigCenterType) (ConfigCenter, error) {
+	fun := "sconfcenter.NewConfigCenter-->"
+	switch t {
+	case ApolloConfigCenter:
+		return newApolloConfigCenter(), nil
+	default:
+		return nil, fmt.Errorf("%s unsupported config center type:%v", fun, t)
+	}
+}
 
 var defaultConfigCenter ConfigCenter
 
@@ -29,66 +54,39 @@ type ConfigCenter interface {
 }
 
 func Init(ctx context.Context, serviceName string, namespaceNames []string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.Init")
-	defer span.Finish()
-
 	defaultConfigCenter = newApolloConfigCenter()
 	return defaultConfigCenter.Init(ctx, serviceName, namespaceNames)
 }
 
 func Stop(ctx context.Context) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.Stop")
-	defer span.Finish()
-
 	return defaultConfigCenter.Stop(ctx)
 }
 
 func SubscribeNamespaces(ctx context.Context, namespaceNames []string) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.SubscribeNamespaces")
-	defer span.Finish()
-
 	return defaultConfigCenter.SubscribeNamespaces(ctx, namespaceNames)
 }
 
 func GetString(ctx context.Context, key string) (string, bool) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.GetString")
-	defer span.Finish()
-
 	return defaultConfigCenter.GetString(ctx, key)
 }
 
 func GetStringWithNamespace(ctx context.Context, namespace, key string) (string, bool) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.GetStringWithNamespace")
-	defer span.Finish()
-
 	return defaultConfigCenter.GetStringWithNamespace(ctx, namespace, key)
 }
 
 func GetBool(ctx context.Context, key string) (bool, bool) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.GetBool")
-	defer span.Finish()
-
 	return defaultConfigCenter.GetBool(ctx, key)
 }
 
 func GetBoolWithNamespace(ctx context.Context, namespace, key string) (bool, bool) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.GetBoolWithNamespace")
-	defer span.Finish()
-
 	return defaultConfigCenter.GetBoolWithNamespace(ctx, namespace, key)
 }
 
 func GetInt(ctx context.Context, key string) (int, bool) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.GetInt")
-	defer span.Finish()
-
 	return defaultConfigCenter.GetInt(ctx, key)
 }
 
 func GetIntWithNamespace(ctx context.Context, namespace, key string) (int, bool) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "sconfcenter.GetIntWithNamespace")
-	defer span.Finish()
-
 	return defaultConfigCenter.GetIntWithNamespace(ctx, namespace, key)
 }
 

--- a/sconf/center/interface_test.go
+++ b/sconf/center/interface_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	testService   = "authapi"
+	testService   = "base/authapi"
 	testKey       = "key1"
 	testNamespace = "db"
 )
@@ -17,17 +17,31 @@ func TestGetTypedVar(t *testing.T) {
 	_ = Init(ctx, testService, []string{"application"})
 	defer Stop(ctx)
 
-	strVal := GetString(ctx, testKey)
+	strVal, ok := GetString(ctx, testKey)
+	if !ok {
+		t.Errorf("strVal expect:%s to exist", testKey)
+	}
+
 	if strVal != "1" {
 		t.Errorf("strVal expect:1 got:%v", strVal)
 	}
 
-	boolVal := GetBool(ctx, testKey)
+	boolVal, ok := GetBool(ctx, testKey)
+
+	if !ok {
+		t.Errorf("boolVal expect:%s to exist", testKey)
+	}
+
 	if boolVal != true {
 		t.Error("boolVal expect:true got:false")
 	}
 
-	intVal := GetInt(ctx, testKey)
+	intVal, ok := GetInt(ctx, testKey)
+
+	if !ok {
+		t.Errorf("intVal expect:%s to exist", testKey)
+	}
+
 	if intVal != 1 {
 		t.Errorf("intVal expect:1 got:%d", intVal)
 	}
@@ -39,17 +53,27 @@ func TestGetTypedVarWithNamespace(t *testing.T) {
 	_ = Init(ctx, testService, []string{"application", testNamespace})
 	defer Stop(ctx)
 
-	strVal := GetStringWithNamespace(ctx, testNamespace, testKey)
-	if strVal != "0" {
-		t.Errorf("strVal expect:0 got:%v", strVal)
+	strVal, ok := GetStringWithNamespace(ctx, testNamespace, testKey)
+	if ok {
+		t.Errorf("strVal expect:%s to not exist", testKey)
 	}
 
-	boolVal := GetBoolWithNamespace(ctx, testNamespace, testKey)
+	if strVal != "" {
+		t.Errorf("strVal expect:'' got:%v", strVal)
+	}
+
+	boolVal, ok := GetBoolWithNamespace(ctx, testNamespace, testKey)
 	if boolVal != false {
 		t.Error("boolVal expect:false got:true")
 	}
+	if ok {
+		t.Errorf("boolVal expect:%s to not exist", testKey)
+	}
 
-	intVal := GetIntWithNamespace(ctx, testNamespace, testKey)
+	intVal, ok := GetIntWithNamespace(ctx, testNamespace, testKey)
+	if ok {
+		t.Errorf("intVal expect:%s to not exist", testKey)
+	}
 	if intVal != 0 {
 		t.Errorf("intVal expect:0 got:%d", intVal)
 	}


### PR DESCRIPTION
1. 升级 agollo client，之前是单例模式。改成支持多实例
2. conf/center 支持多实例
3. mq/cache 各自生成自己的 conf/center 实例，service 指向 middleware
4. infra.cache 的配置，servicename 使用斜杠隔开