### PR TITLE
use cache data as error message when unmarshal failed

### DIFF
--- a/cache/value/value.go
+++ b/cache/value/value.go
@@ -175,7 +175,7 @@ func (m *Cache) getValueFromCache(ctx context.Context, key, value interface{}) e
 
 	err = json.Unmarshal(data, value)
 	if err != nil {
-		return err
+		return errors.New(string(data))
 	}
 
 	return nil


### PR DESCRIPTION
before:

invalid character 's' looking for beginning of value

after:

"invalidkey:%!(EXTRA string=274043920199696)"