### PR TITLE
Feature sql breaker

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -216,8 +216,12 @@ func SetConfiger(ctx context.Context, configerType constants.ConfigerType) error
 		return err
 	}
 	slog.Infof(ctx, "%s %v configer created", fun, configerType)
+	err = configer.Init(ctx)
+	if err != nil {
+		slog.Errorf(ctx, "%s init configer err:%v", fun, err)
+	}
 	redis.DefaultConfiger = configer
-	return redis.DefaultConfiger.Init(ctx)
+	return err
 }
 
 func WatchUpdate(ctx context.Context) {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -76,10 +76,12 @@ func NewCacheByNamespace(ctx context.Context, namespace, prefix string, expire i
 
 func (m *Cache) setData(key string, data CacheData) error {
 	fun := "Cache.setData -->"
+	expire := time.Duration(m.expire) * time.Second
 	sdata, merr := data.Marshal()
 	if merr != nil {
 		sdata = []byte(merr.Error())
 		merr = fmt.Errorf("%s marshal err, cache key:%s err:%s", fun, key, merr)
+		expire = constants.CacheDirtyExpireTime
 	}
 
 	client, err := m.getRedisClient()
@@ -87,7 +89,7 @@ func (m *Cache) setData(key string, data CacheData) error {
 		return fmt.Errorf("%s get redis client err:%s", fun, err.Error())
 	}
 
-	err = client.Set(m.fixKey(key), sdata, time.Duration(m.expire)*time.Second).Err()
+	err = client.Set(m.fixKey(key), sdata, expire).Err()
 	if err != nil {
 		return fmt.Errorf("%s set err, cache key:%s err:%s", fun, key, err)
 	}

--- a/cache/constants/constants.go
+++ b/cache/constants/constants.go
@@ -2,12 +2,17 @@ package constants
 
 import (
 	"fmt"
+	"time"
 )
 
 const (
 	SpanLogKeyKey    = "key"
 	SpanLogCacheType = "cache"
 	SpanLogOp        = "op"
+)
+
+const (
+	CacheDirtyExpireTime = time.Second * 60
 )
 
 var RedisNil = fmt.Sprintf("redis: nil")

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -2,11 +2,16 @@ package cache
 
 import (
 	"context"
+	"time"
+
 	go_redis "github.com/go-redis/redis"
 	"github.com/shawnfeng/sutil/cache/redis"
 	"github.com/shawnfeng/sutil/scontext"
 	"github.com/shawnfeng/sutil/slog/slog"
-	"time"
+)
+
+const (
+	defaultTimeout = time.Second * 2
 )
 
 func NewCommonRedis(serverName string, poolSize int) (*RedisClient, error) {
@@ -24,8 +29,8 @@ func NewRedisByNamespace(ctx context.Context, namespace string) (*RedisClient, e
 		slog.Errorf(ctx, "%s GetInstance: namespace %s, err: %s", fun, namespace, err.Error())
 	}
 	return &RedisClient{
-		client:      client,
-		namespace:   namespace,
+		client:    client,
+		namespace: namespace,
 	}, err
 }
 
@@ -38,14 +43,14 @@ func getInstanceConf(ctx context.Context, namespace string) *redis.InstanceConf 
 }
 
 type RedisClient struct {
-	client      *redis.Client
-	namespace   string
+	client    *redis.Client
+	namespace string
 }
 
 func newRedisClient(addr, serverName string, poolSize int) (*RedisClient, error) {
 	fun := "newRedisClient-->"
 
-	client, err := redis.NewDefaultClient(context.Background(), serverName, addr, WrapperTypeCache, poolSize, false, time.Second)
+	client, err := redis.NewDefaultClient(context.Background(), serverName, addr, WrapperTypeCache, poolSize, false, defaultTimeout)
 	if err != nil {
 		slog.Errorf(context.TODO(), "%s NewDefaultClient: serverName %s err: %s", fun, serverName, err.Error())
 	}

--- a/cache/redis/config.go
+++ b/cache/redis/config.go
@@ -17,6 +17,13 @@ import (
 )
 
 const (
+	apolloConfigSep = "."
+
+	apolloConfigKeyAddr       = "addr"
+	apolloConfigKeyPoolSize   = "poolsize"
+	apolloConfigKeyTimeout    = "timeout"
+	apolloConfigKeyUseWrapper = "usewrapper"
+
 	defaultPoolSize          = 128
 	defaultTimeoutNumSeconds = 3
 	defaultUseWrapper        = true
@@ -138,14 +145,6 @@ func (m *EtcdConfig) Watch(ctx context.Context) <-chan *center.ChangeEvent {
 	return nil
 }
 
-const (
-	apolloConfigSep = "."
-
-	apolloConfigKeyAddr       = "addr"
-	apolloConfigKeyPoolSize   = "poolsize"
-	apolloConfigKeyTimeout    = "timeout"
-	apolloConfigKeyUseWrapper = "usewrapper"
-)
 
 type ApolloConfig struct {
 	watchOnce sync.Once

--- a/cache/redis/instance.go
+++ b/cache/redis/instance.go
@@ -7,11 +7,13 @@ package redis
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+
 	"github.com/shawnfeng/sutil/cache/constants"
 	"github.com/shawnfeng/sutil/sconf/center"
 	"github.com/shawnfeng/sutil/slog/slog"
-	"strings"
-	"sync"
 )
 
 const (
@@ -160,8 +162,10 @@ func (m *InstanceManager) applyChangeEvent(ctx context.Context, ce *center.Chang
 func (m *InstanceManager) Watch(ctx context.Context) {
 	fun := "InstanceManager.Watch-->"
 	defer func() {
-		if r := recover(); r != nil {
-			slog.Errorf(ctx, "%s recover r: %v", fun, r)
+		if err := recover(); err != nil {
+			buf := make([]byte, 4096)
+			buf = buf[:runtime.Stack(buf, false)]
+			slog.Errorf(ctx, "%s recover err: %v, stack: %s", fun, err, string(buf))
 		}
 	}()
 	m.watchOnce.Do(func() {

--- a/cache/redisext/redisext.go
+++ b/cache/redisext/redisext.go
@@ -900,9 +900,12 @@ func SetConfiger(ctx context.Context, configerType constants.ConfigerType) error
 		slog.Errorf(ctx, "%s create configer err:%v", fun, err)
 		return err
 	}
-	slog.Infof(ctx, "%s %v configer created", fun, configerType)
+	err = configer.Init(ctx)
+	if err != nil {
+		slog.Errorf(ctx, "%s init configer err:%v", fun, err)
+	}
 	redis.DefaultConfiger = configer
-	return redis.DefaultConfiger.Init(ctx)
+	return err
 }
 
 func WatchUpdate(ctx context.Context) {

--- a/cache/value/value.go
+++ b/cache/value/value.go
@@ -262,8 +262,12 @@ func SetConfiger(ctx context.Context, configerType constants.ConfigerType) error
 		return err
 	}
 	slog.Infof(ctx, "%s %v configer created", fun, configerType)
+	err = configer.Init(ctx)
+	if err != nil {
+		slog.Errorf(ctx, "%s init configer err:%v", fun, err)
+	}
 	redis.DefaultConfiger = configer
-	return redis.DefaultConfiger.Init(ctx)
+	return err
 }
 
 func WatchUpdate(ctx context.Context) {

--- a/cache/value/value.go
+++ b/cache/value/value.go
@@ -8,7 +8,7 @@
 
 package value
 
-import  (
+import (
 	"context"
 	"encoding/json"
 	"errors"
@@ -213,17 +213,20 @@ func (m *Cache) getValueFromCache(ctx context.Context, key, value interface{}) e
 
 func (m *Cache) loadValueToCache(ctx context.Context, key interface{}) (data []byte, err error) {
 	fun := "Cache.loadValueToCache -->"
+	expire := m.expire
 
 	value, err := m.load(ctx, key)
 	if err != nil {
 		slog.Warnf(ctx, "%s load err, cache key:%v err:%v", fun, key, err)
 		data = []byte(err.Error())
+		expire = constants.CacheDirtyExpireTime
 
 	} else {
 		data, err = json.Marshal(value)
 		if err != nil {
 			slog.Errorf(ctx, "%s marshal err, cache key:%v err:%v", fun, key, err)
 			data = []byte(err.Error())
+			expire = constants.CacheDirtyExpireTime
 		}
 	}
 
@@ -239,7 +242,7 @@ func (m *Cache) loadValueToCache(ctx context.Context, key interface{}) (data []b
 		return nil, err
 	}
 
-	rerr := client.Set(ctx, skey, data, m.expire).Err()
+	rerr := client.Set(ctx, skey, data, expire).Err()
 	if rerr != nil {
 		slog.Errorf(ctx, "%s set err, cache key:%v rerr:%v", fun, key, rerr)
 	}

--- a/dbrouter/breaker.go
+++ b/dbrouter/breaker.go
@@ -1,0 +1,126 @@
+package dbrouter
+
+import (
+	"context"
+	"fmt"
+	"gitlab.pri.ibanyu.com/middleware/seaweed/xlog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/shawnfeng/sutil/sconf/center"
+	"github.com/shawnfeng/sutil/slog"
+)
+
+var (
+	configCenter center.ConfigCenter
+)
+
+const (
+	globalGranularityKey = "global.granularity" // 精度
+	globalThresholdKey   = "global.threshold"   // 精度内阈值
+	globalBreakerGapKey  = "global.breakergap"  // 触发熔断后的熔断间隔,单位: 秒
+)
+
+type BreakerManager struct {
+	Lock     sync.Mutex
+	Breakers map[string]*Breaker
+}
+
+type Breaker struct {
+	Lock          sync.Mutex
+	Rejected      int32
+	RejectedStart int64
+	Count         int32
+}
+
+var bm *BreakerManager
+
+func statBreaker(table string, err error) {
+	if err != nil && strings.Contains(err.Error(), "timeout") {
+		bm.Lock.Lock()
+		if _, ok := bm.Breakers[table]; !ok {
+			breaker := new(Breaker)
+			breaker.Run()
+			bm.Breakers[table] = breaker
+		}
+		breaker := bm.Breakers[table]
+		bm.Lock.Unlock()
+		atomic.AddInt32(&breaker.Count, 1)
+	}
+}
+
+func Entry(table string) bool {
+	bm.Lock.Lock()
+	breaker := bm.Breakers[table]
+	bm.Lock.Unlock()
+	if atomic.LoadInt32(&breaker.Rejected) == 1 {
+		fmt.Println("rejected...")
+		return false
+	}
+	fmt.Println("accepted...")
+	return true
+}
+
+func (breaker *Breaker) Run() {
+	go func() {
+		granularityStr, exist := configCenter.GetStringWithNamespace(context.TODO(), center.DefaultApolloMysqlNamespace, globalGranularityKey)
+		if !exist {
+			xlog.Warnf(context.TODO(), "dbrouter: get granularity from apollo failed, exist: %v", exist)
+			granularityStr = "1s"
+		}
+		granularity, err := time.ParseDuration(granularityStr)
+		if err != nil {
+			xlog.Warnf(context.TODO(), "dbrouter: granularity in apollo is invalid, %s", granularityStr)
+			granularity = time.Second * 1
+		}
+		tickC := time.Tick(granularity)
+		for {
+			select {
+			case <-tickC:
+				threshold, exist := configCenter.GetIntWithNamespace(context.TODO(), center.DefaultApolloMysqlNamespace, globalThresholdKey)
+				if !exist {
+					xlog.Warnf(context.TODO(), "dbrouter: get threshold from apollo failed, exist: %v", exist)
+					threshold = 10
+				}
+				breakerGap, exist := configCenter.GetIntWithNamespace(context.TODO(), center.DefaultApolloMysqlNamespace, globalBreakerGapKey)
+				if !exist {
+					xlog.Warnf(context.TODO(), "dbrouter: get breakGap from apollo failed, exist: %v", exist)
+					breakerGap = 10
+				}
+				if atomic.LoadInt32(&breaker.Count) > int32(threshold) {
+					atomic.StoreInt32(&breaker.Rejected, 1)
+					breaker.RejectedStart = time.Now().Unix()
+				} else {
+					now := time.Now().Unix()
+					if now-breaker.RejectedStart > int64(breakerGap) {
+						atomic.StoreInt32(&breaker.Rejected, 0)
+					}
+				}
+				atomic.StoreInt32(&breaker.Count, 0)
+			}
+		}
+	}()
+}
+
+func initConfig() error {
+	var err error
+	configCenter, err = center.NewConfigCenter(center.ApolloConfigCenter)
+	if err != nil {
+		return err
+	}
+	err = configCenter.Init(context.TODO(), center.DefaultApolloMiddlewareService, []string{center.DefaultApolloMysqlNamespace})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	bm = &BreakerManager{Breakers: make(map[string]*Breaker)}
+	err := initConfig()
+	if err != nil {
+		slog.Panicf("dbrouter: init apollo config failed, err: %v", err)
+	}
+}

--- a/dbrouter/breaker.go
+++ b/dbrouter/breaker.go
@@ -2,14 +2,13 @@ package dbrouter
 
 import (
 	"context"
-	"gitlab.pri.ibanyu.com/middleware/seaweed/xlog"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/shawnfeng/sutil/sconf/center"
-	"github.com/shawnfeng/sutil/slog"
+	"github.com/shawnfeng/sutil/slog/slog"
 )
 
 var (
@@ -68,12 +67,12 @@ func (breaker *Breaker) Run() {
 	go func() {
 		granularityStr, exist := configCenter.GetStringWithNamespace(context.TODO(), center.DefaultApolloMysqlNamespace, globalGranularityKey)
 		if !exist {
-			xlog.Warnf(context.TODO(), "dbrouter: get granularity from apollo failed, exist: %v", exist)
+			slog.Warnf(context.TODO(), "dbrouter: get granularity from apollo failed, exist: %v", exist)
 			granularityStr = "1s"
 		}
 		granularity, err := time.ParseDuration(granularityStr)
 		if err != nil {
-			xlog.Warnf(context.TODO(), "dbrouter: granularity in apollo is invalid, %s", granularityStr)
+			slog.Warnf(context.TODO(), "dbrouter: granularity in apollo is invalid, %s", granularityStr)
 			granularity = time.Second * 1
 		}
 		tickC := time.Tick(granularity)
@@ -85,12 +84,12 @@ func (breaker *Breaker) Run() {
 			case <-tickC:
 				threshold, exist := configCenter.GetIntWithNamespace(context.TODO(), center.DefaultApolloMysqlNamespace, globalThresholdKey)
 				if !exist {
-					xlog.Warnf(context.TODO(), "dbrouter: get threshold from apollo failed, exist: %v", exist)
+					slog.Warnf(context.TODO(), "dbrouter: get threshold from apollo failed, exist: %v", exist)
 					threshold = defaultThreshold
 				}
 				breakerGap, exist := configCenter.GetIntWithNamespace(context.TODO(), center.DefaultApolloMysqlNamespace, globalBreakerGapKey)
 				if !exist {
-					xlog.Warnf(context.TODO(), "dbrouter: get breakGap from apollo failed, exist: %v", exist)
+					slog.Warnf(context.TODO(), "dbrouter: get breakGap from apollo failed, exist: %v", exist)
 					breakerGap = defaultBreakerGap
 				}
 				if atomic.LoadInt32(&breaker.Count) > int32(threshold) {
@@ -124,6 +123,6 @@ func init() {
 	bm = &BreakerManager{Breakers: make(map[string]*Breaker)}
 	err := initConfig()
 	if err != nil {
-		slog.Panicf("dbrouter: init apollo config failed, err: %v", err)
+		slog.Panicf(context.TODO(), "dbrouter: init apollo config failed, err: %v", err)
 	}
 }

--- a/dbrouter/breaker.go
+++ b/dbrouter/breaker.go
@@ -40,7 +40,7 @@ type Breaker struct {
 var bm *BreakerManager
 
 func statBreaker(table string, err error) {
-	if err != nil && strings.Contains(err.Error(), "timeout") {
+	if err != nil && (strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "invalid connection")) {
 		bm.Lock.Lock()
 		if _, ok := bm.Breakers[table]; !ok {
 			breaker := new(Breaker)
@@ -57,8 +57,10 @@ func Entry(table string) bool {
 	bm.Lock.Lock()
 	breaker := bm.Breakers[table]
 	bm.Lock.Unlock()
-	if atomic.LoadInt32(&breaker.Rejected) == 1 {
-		return false
+	if breaker != nil {
+		if atomic.LoadInt32(&breaker.Rejected) == 1 {
+			return false
+		}
 	}
 	return true
 }

--- a/dbrouter/breaker.go
+++ b/dbrouter/breaker.go
@@ -2,7 +2,6 @@ package dbrouter
 
 import (
 	"context"
-	"fmt"
 	"gitlab.pri.ibanyu.com/middleware/seaweed/xlog"
 	"strings"
 	"sync"
@@ -23,6 +22,7 @@ const (
 	globalBreakerGapKey  = "global.breakergap"  // 触发熔断后的熔断间隔,单位: 秒
 )
 
+// TOOD 简单计数法实现熔断操作，后续改为滑动窗口或三方组件的方式
 type BreakerManager struct {
 	Lock     sync.Mutex
 	Breakers map[string]*Breaker
@@ -56,10 +56,8 @@ func Entry(table string) bool {
 	breaker := bm.Breakers[table]
 	bm.Lock.Unlock()
 	if atomic.LoadInt32(&breaker.Rejected) == 1 {
-		fmt.Println("rejected...")
 		return false
 	}
-	fmt.Println("accepted...")
 	return true
 }
 

--- a/dbrouter/breaker_test.go
+++ b/dbrouter/breaker_test.go
@@ -2,9 +2,9 @@ package dbrouter
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
-	"fmt"
 )
 
 func TestEntry(t *testing.T) {

--- a/dbrouter/breaker_test.go
+++ b/dbrouter/breaker_test.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"testing"
 	"time"
+	"fmt"
 )
 
 func TestEntry(t *testing.T) {
 	go func() {
 		for {
-			Entry("test")
+			fmt.Printf("Entry: %v\n", Entry("test"))
 			time.Sleep(time.Millisecond * 1000)
 		}
 	}()

--- a/dbrouter/breaker_test.go
+++ b/dbrouter/breaker_test.go
@@ -10,14 +10,14 @@ import (
 func TestEntry(t *testing.T) {
 	go func() {
 		for {
-			fmt.Printf("Entry: %v\n", Entry("test"))
+			fmt.Printf("Entry: %v\n", Entry("group", "test"))
 			time.Sleep(time.Millisecond * 1000)
 		}
 	}()
 
 	go func() {
 		for i := 0; i < 20; i++ {
-			statBreaker("test", errors.New("timeout"))
+			statBreaker("group", "test", errors.New("timeout"))
 		}
 	}()
 	select {}

--- a/dbrouter/breaker_test.go
+++ b/dbrouter/breaker_test.go
@@ -1,0 +1,23 @@
+package dbrouter
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEntry(t *testing.T) {
+	go func() {
+		for {
+			Entry("test")
+			time.Sleep(time.Millisecond * 1000)
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 20; i++ {
+			statBreaker("test", errors.New("timeout"))
+		}
+	}()
+	select {}
+}

--- a/dbrouter/dbrouter.go
+++ b/dbrouter/dbrouter.go
@@ -6,10 +6,8 @@ package dbrouter
 
 import (
 	"context"
-	"fmt"
 	"errors"
-
-	"gitlab.pri.ibanyu.com/middleware/seaweed/xlog"
+	"fmt"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
@@ -115,7 +113,7 @@ func (m *Router) SqlExec(ctx context.Context, cluster string, query func(*DB, []
 	}
 
 	if !Entry(table){
-		xlog.Errorf(ctx, "trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", cluster, table)
+		slog.Errorf(ctx, "trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", cluster, table)
 		return errors.New("sql cause breaker, because too many timeout")
 	}
 	err = query(db, tmptables)
@@ -178,7 +176,7 @@ func (m *Router) OrmExec(ctx context.Context, cluster string, query func(*GormDB
 	}
 
 	if !Entry(table){
-		xlog.Errorf(ctx, "trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", cluster, table)
+		slog.Errorf(ctx, "trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", cluster, table)
 		return errors.New("sql cause breaker, because too many timeout")
 	}
 

--- a/dbrouter/dbrouter.go
+++ b/dbrouter/dbrouter.go
@@ -96,6 +96,12 @@ func (m *Router) SqlExec(ctx context.Context, cluster string, query func(*DB, []
 		log.String(spanLogKeyCluster, cluster),
 		log.String(spanLogKeyTable, table))
 
+	// check breaker
+	if !Entry(cluster, table){
+		slog.Errorf(ctx, "%s trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", fun, cluster, table)
+		return errors.New("sql cause breaker, because too many timeout")
+	}
+
 	db, err := m.sqlPrepare(ctx, cluster, table)
 	if err != nil {
 		return err
@@ -112,12 +118,9 @@ func (m *Router) SqlExec(ctx context.Context, cluster string, query func(*DB, []
 		tmptables = append(tmptables, item)
 	}
 
-	if !Entry(table){
-		slog.Errorf(ctx, "trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", cluster, table)
-		return errors.New("sql cause breaker, because too many timeout")
-	}
 	err = query(db, tmptables)
-	statBreaker(table, err)
+	// record breaker
+	statBreaker(cluster, table, err)
 	return err
 }
 
@@ -159,6 +162,12 @@ func (m *Router) OrmExec(ctx context.Context, cluster string, query func(*GormDB
 		log.String(spanLogKeyCluster, cluster),
 		log.String(spanLogKeyTable, table))
 
+	// check breaker
+	if !Entry(cluster, table){
+		slog.Errorf(ctx, "%s trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", fun, cluster, table)
+		return errors.New("sql cause breaker, because too many timeout")
+	}
+
 	db, err := m.ormPrepare(ctx, cluster, table)
 	if err != nil {
 		return err
@@ -175,13 +184,9 @@ func (m *Router) OrmExec(ctx context.Context, cluster string, query func(*GormDB
 		tmptables = append(tmptables, item)
 	}
 
-	if !Entry(table){
-		slog.Errorf(ctx, "trigger tidb breaker, because too many timeout sqls, cluster: %s, table: %s", cluster, table)
-		return errors.New("sql cause breaker, because too many timeout")
-	}
-
 	err = query(db, tmptables)
-	statBreaker(table, err)
+	// stat breaker
+	statBreaker(cluster, table, err)
 	return err
 }
 
@@ -230,6 +235,10 @@ func (m *Router) mongoPrepare(ctx context.Context, consistency mode, cluster, ta
 
 func (m *Router) mongoExec(ctx context.Context, consistency mode, cluster, table string, query func(*mgo.Collection) error) error {
 	fun := "Router.mongoExec -->"
+	if !Entry(cluster, table){
+		slog.Errorf(ctx, "%s trigger mongodb breaker, because too many timeout query, cluster: %s, table: %s", fun, cluster, table)
+		return errors.New("mongo query cause breaker, because too many timeout")
+	}
 
 	span, ctx := opentracing.StartSpanFromContext(ctx, "dbrouter.mongoExec")
 	defer span.Finish()
@@ -252,5 +261,7 @@ func (m *Router) mongoExec(ctx context.Context, consistency mode, cluster, table
 		slog.Tracef(ctx, "%s const:%d cls:%s table:%s dur:%d", fun, consistency, cluster, table, dur)
 	}()
 
-	return query(coll)
+	err = query(coll)
+	statBreaker(cluster, table, err)
+	return err
 }

--- a/dbrouter/gorm.go
+++ b/dbrouter/gorm.go
@@ -28,8 +28,8 @@ func dialByGorm(info *Sql) (db *gorm.DB, err error) {
 	fun := "dialByGorm -->"
 
 	var dataSourceName string
-	if info.dbType == DB_TYPE_MYSQL { // timeout: 3s readTimeout: 10s writeTimeout: 10s, TODO: dynamic config
-		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=True&loc=Local&charset=utf8mb4&collation=utf8mb4_unicode_ci&timeout=3s&readTimeout=10s&writeTimeout=10s", info.userName, info.passWord, info.dbAddr, info.dbName)
+	if info.dbType == DB_TYPE_MYSQL { // timeout: 3s readTimeout: 5s writeTimeout: 5s, TODO: dynamic config
+		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=True&loc=Local&charset=utf8mb4&collation=utf8mb4_unicode_ci&timeout=3s&readTimeout=5s&writeTimeout=5s", info.userName, info.passWord, info.dbAddr, info.dbName)
 
 	} else if info.dbType == DB_TYPE_POSTGRES {
 		dataSourceName = fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable",

--- a/dbrouter/gorm.go
+++ b/dbrouter/gorm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	"github.com/shawnfeng/sutil/slog/slog"
+	"time"
 )
 
 type GormDB struct {
@@ -27,8 +28,8 @@ func dialByGorm(info *Sql) (db *gorm.DB, err error) {
 	fun := "dialByGorm -->"
 
 	var dataSourceName string
-	if info.dbType == DB_TYPE_MYSQL {
-		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=True&loc=Local&charset=utf8mb4&collation=utf8mb4_unicode_ci", info.userName, info.passWord, info.dbAddr, info.dbName)
+	if info.dbType == DB_TYPE_MYSQL { // timeout: 3s readTimeout: 10s writeTimeout: 10s, TODO: dynamic config
+		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=True&loc=Local&charset=utf8mb4&collation=utf8mb4_unicode_ci&timeout=3s&readTimeout=10s&writeTimeout=10s", info.userName, info.passWord, info.dbAddr, info.dbName)
 
 	} else if info.dbType == DB_TYPE_POSTGRES {
 		dataSourceName = fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable",
@@ -40,6 +41,7 @@ func dialByGorm(info *Sql) (db *gorm.DB, err error) {
 	if err == nil {
 		gormdb.DB().SetMaxIdleConns(8)
 		gormdb.DB().SetMaxOpenConns(128)
+		gormdb.DB().SetConnMaxLifetime(time.Hour*6)
 	}
 
 	return gormdb, err

--- a/dbrouter/instance_test.go
+++ b/dbrouter/instance_test.go
@@ -1,0 +1,31 @@
+package dbrouter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestQueryTimeout(t *testing.T) {
+	ctx := context.TODO()
+	router, err := NewRouter(nil)
+	if err != nil {
+		t.Errorf("init router failed, err: %v", err)
+	}
+	for i:=0;i<16;i++ {
+		go func() {
+			for {
+				err = router.SqlExec(ctx, "COURSEWAREX", func(db *DB, tables []interface{}) (err error) {
+					_, err = db.Query("select sleep(10)")
+					return err
+				}, "coursewarex_1")
+				if err != nil {
+					fmt.Printf("router exec failed, %v", err)
+				}
+				time.Sleep(time.Millisecond * 50)
+			}
+		}()
+	}
+	select{}
+}

--- a/dbrouter/mongo_test.go
+++ b/dbrouter/mongo_test.go
@@ -1,0 +1,36 @@
+package dbrouter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"gopkg.in/mgo.v2"
+)
+
+func TestMongoTimeout(t *testing.T) {
+	ctx := context.TODO()
+	router, err := NewRouter(nil)
+	if err != nil {
+		t.Errorf("init router failed, err: %v", err)
+	}
+	query := func(c *mgo.Collection) error {
+		n, err := c.Count()
+		fmt.Println(n)
+		return err
+	}
+	for i := 0; i < 16; i++ {
+		go func() {
+			for {
+				err = router.MongoExecEventual(ctx, "STAT", "dbrouter_oprecord", query)
+				if err != nil {
+					fmt.Printf("router exec failed, %v", err)
+				}
+				time.Sleep(time.Millisecond * 50)
+			}
+		}()
+
+	}
+	select{}
+}

--- a/dbrouter/sqlx.go
+++ b/dbrouter/sqlx.go
@@ -30,8 +30,8 @@ func dialBySqlx(info *Sql) (db *sqlx.DB, err error) {
 	fun := "dialBySqlx -->"
 
 	var dataSourceName string
-	if info.dbType == DB_TYPE_MYSQL { // timeout: 3s readTimeout: 10s writeTimeout: 10s, TODO: dynamic config
-		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4&collation=utf8mb4_unicode_ci&timeout=3s&readTimeout=10s&writeTimeout=10s", info.userName, info.passWord, info.dbAddr, info.dbName)
+	if info.dbType == DB_TYPE_MYSQL { // timeout: 3s readTimeout: 5s writeTimeout: 5s, TODO: dynamic config
+		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4&collation=utf8mb4_unicode_ci&timeout=3s&readTimeout=5s&writeTimeout=5s", info.userName, info.passWord, info.dbAddr, info.dbName)
 
 	} else if info.dbType == DB_TYPE_POSTGRES {
 		dataSourceName = fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable",

--- a/dbrouter/sqlx.go
+++ b/dbrouter/sqlx.go
@@ -30,8 +30,8 @@ func dialBySqlx(info *Sql) (db *sqlx.DB, err error) {
 	fun := "dialBySqlx -->"
 
 	var dataSourceName string
-	if info.dbType == DB_TYPE_MYSQL {
-		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4&collation=utf8mb4_unicode_ci", info.userName, info.passWord, info.dbAddr, info.dbName)
+	if info.dbType == DB_TYPE_MYSQL { // timeout: 3s readTimeout: 10s writeTimeout: 10s, TODO: dynamic config
+		dataSourceName = fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4&collation=utf8mb4_unicode_ci&timeout=3s&readTimeout=10s&writeTimeout=10s", info.userName, info.passWord, info.dbAddr, info.dbName)
 
 	} else if info.dbType == DB_TYPE_POSTGRES {
 		dataSourceName = fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable",

--- a/mq/instance.go
+++ b/mq/instance.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/shawnfeng/sutil/sconf/center"
-	"github.com/shawnfeng/sutil/slog/slog"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/shawnfeng/sutil/sconf/center"
+	"github.com/shawnfeng/sutil/slog/slog"
 )
 
 var defaultInstanceManager = NewInstanceManager()
@@ -232,8 +234,10 @@ func (m *InstanceManager) applyChangeEvent(ctx context.Context, ce *center.Chang
 func (m *InstanceManager) watch(ctx context.Context) {
 	fun := "InstanceManager.watch-->"
 	defer func() {
-		if r := recover(); r != nil {
-			slog.Errorf(ctx, "%s recover r: %v", fun, r)
+		if err := recover(); err != nil {
+			buf := make([]byte, 4096)
+			buf = buf[:runtime.Stack(buf, false)]
+			slog.Errorf(ctx, "%s recover err: %v, stack: %s", fun, err, string(buf))
 		}
 	}()
 	m.watchOnce.Do(func() {

--- a/sconf/center/constants.go
+++ b/sconf/center/constants.go
@@ -5,5 +5,6 @@ const (
 
 	DefaultApolloMQNamespace    = "infra.mq"
 	DefaultApolloCacheNamespace = "infra.cache"
+	DefaultApolloMysqlNamespace = "infra.mysql"
 	DefaultApolloTraceNamespace = "infra.trace"
 )


### PR DESCRIPTION
1.dbrouter: add read/write timeout in sqlx and gorm
2.dbrouter: add breaker in sql query and mongo query
3.cache: optimize cache expire time when get data from backend database failed
4.dbrouter: dbrouter: optimize mongo read/write timeout to 10s
5.cache: fix panic bug of config init