### PR TITLE
redisext: add lua script and global lock

### DIFF
--- a/cache/redisext/lock.go
+++ b/cache/redisext/lock.go
@@ -9,9 +9,9 @@ import (
 const (
 	retryTimeGap = time.Millisecond * 20
 
-	initState = "1"
-	doing     = "100"
-	done      = "200"
+	InitState = "0"
+	Doing     = "1"
+	Done      = "99"
 )
 
 // Lock get a global lock identified by key, if failed, return quickly
@@ -57,12 +57,12 @@ func (m *RedisExt) Unlock(ctx context.Context, key string, value interface{}) (b
 //
 // 返回参数:
 // @canHandle: 是否可以继续执行该笔业务记录，
-// @state: 该笔业务记录的状态，initState：初始状态 done: 处理完成 doing：正在处理中
+// @state: 该笔业务记录的状态，InitState：初始状态 Done: 处理完成 Doing：正在处理中
 // @err: 异常错误
 //
 // 特别说明:
-// 可以继续执行该笔业务记录的情况有: 记录为初始状态或者记录为doing状态，且超过了timeout这个执行时间
-func (m *RedisExt) TryAcquire(ctx context.Context, key string, timeout, expiration time.Duration) (canHandle bool, state string, err error) {
+// 可以继续执行该笔业务记录的情况有: 记录为初始状态或者记录为Doing状态，且超过了timeout这个执行时间
+func (m *RedisExt) TryAcquire(ctx context.Context, key string, expiration, timeout time.Duration) (canHandle bool, state string, err error) {
 	value := time.Now().Add(timeout).Second()
 	r, err := m.SetNX(ctx, key, value, expiration)
 	if err != nil {
@@ -70,36 +70,36 @@ func (m *RedisExt) TryAcquire(ctx context.Context, key string, timeout, expirati
 	}
 	// 加锁成功，可以继续业务处理
 	if r {
-		return true, initState, nil
+		return true, InitState, nil
 	}
 
 	// 加锁失败，需要分情况判断
 	// 状态已经被确认，不需要重新处理业务，可以根据状态进行自己所需操作，如直接返回成功
 	s, err := m.Get(ctx, key)
-	if s == done {
-		return false, done, nil
+	if s == Done {
+		return false, Done, nil
 	}
 
 	// 当前时间小于业务处理过期时间，应该是有其他的进程/线程在处理，不需要处理业务，返回处理中
 	now := time.Now().Second()
 	result, _ := strconv.Atoi(s)
 	if now < result {
-		return false, doing, nil
+		return false, Doing, nil
 	}
 
-	// 锁处于处理中，当前时间大于业务处理过期时间，
+	// 锁处于处理中，当前时间大于业务处理过期时间，类似乐观锁
 	delta := now - result + int(timeout.Seconds())
 	r1, err := m.IncrBy(ctx, key, int64(delta))
 	if r1 == int64(result+delta) {
-		return true, doing, nil
+		return true, Doing, nil
 	} else {
 		m.DecrBy(ctx, key, int64(delta))
 	}
-	return false, doing, nil
+	return false, Doing, nil
 }
 
 // Confirm 确定业务处理完成
 func (m *RedisExt) Confirm(ctx context.Context, key string) error {
-	_, err := m.Set(ctx, key, done, 0)
+	_, err := m.Set(ctx, key, Done, 0)
 	return err
 }

--- a/cache/redisext/lock.go
+++ b/cache/redisext/lock.go
@@ -20,10 +20,7 @@ func (m *RedisExt) Lock(ctx context.Context, key string, value interface{}, expi
 	if err != nil {
 		return false, err
 	}
-	if !r {
-		return false, nil
-	}
-	return true, nil
+	return r, nil
 }
 
 // LockWithTimeout will retry get lock in timeout every retryTimeGap

--- a/cache/redisext/lock.go
+++ b/cache/redisext/lock.go
@@ -1,0 +1,105 @@
+package redisext
+
+import (
+	"context"
+	"strconv"
+	"time"
+)
+
+const (
+	retryTimeGap = time.Millisecond * 20
+
+	initState = "1"
+	doing     = "100"
+	done      = "200"
+)
+
+// Lock get a global lock identified by key, if failed, return quickly
+func (m *RedisExt) Lock(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error) {
+	r, err := m.SetNX(ctx, key, value, expiration)
+	if err != nil {
+		return false, err
+	}
+	if !r {
+		return false, nil
+	}
+	return true, nil
+}
+
+// LockWithTimeout will retry get lock in timeout every retryTimeGap
+func (m *RedisExt) LockWithTimeout(ctx context.Context, key string, value interface{}, expiration, timeout time.Duration) (r bool, err error) {
+	for timeout > 0 {
+		r, err = m.SetNX(ctx, key, value, expiration)
+		if err != nil || !r {
+			time.Sleep(retryTimeGap)
+			timeout = timeout - retryTimeGap
+		}
+	}
+	return r, err
+}
+
+// Unlock release lock with check lock value
+func (m *RedisExt) Unlock(ctx context.Context, key string, value interface{}) (bool, error) {
+	src := "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
+	script := NewScript(src)
+	r, err := m.Eval(ctx, script, []string{key}, value)
+	if err != nil {
+		return false, err
+	}
+	return r.(int64) == 1, nil
+}
+
+// TryAcquire 通过特殊的全局锁，保证以key为依据的业务操作是幂等的，可能的情况如下:
+//
+// 入口参数:
+// @timeout: 业务操作的超时时间，比如: 2min
+// @expiration: 业务记录过期时间，比如: 24h
+//
+// 返回参数:
+// @canHandle: 是否可以继续执行该笔业务记录，
+// @state: 该笔业务记录的状态，initState：初始状态 done: 处理完成 doing：正在处理中
+// @err: 异常错误
+//
+// 特别说明:
+// 可以继续执行该笔业务记录的情况有: 记录为初始状态或者记录为doing状态，且超过了timeout这个执行时间
+func (m *RedisExt) TryAcquire(ctx context.Context, key string, timeout, expiration time.Duration) (canHandle bool, state string, err error) {
+	value := time.Now().Add(timeout).Second()
+	r, err := m.SetNX(ctx, key, value, expiration)
+	if err != nil {
+		return false, "unknown", err
+	}
+	// 加锁成功，可以继续业务处理
+	if r {
+		return true, initState, nil
+	}
+
+	// 加锁失败，需要分情况判断
+	// 状态已经被确认，不需要重新处理业务，可以根据状态进行自己所需操作，如直接返回成功
+	s, err := m.Get(ctx, key)
+	if s == done {
+		return false, done, nil
+	}
+
+	// 当前时间小于业务处理过期时间，应该是有其他的进程/线程在处理，不需要处理业务，返回处理中
+	now := time.Now().Second()
+	result, _ := strconv.Atoi(s)
+	if now < result {
+		return false, doing, nil
+	}
+
+	// 锁处于处理中，当前时间大于业务处理过期时间，
+	delta := now - result + int(timeout.Seconds())
+	r1, err := m.IncrBy(ctx, key, int64(delta))
+	if r1 == int64(result+delta) {
+		return true, doing, nil
+	} else {
+		m.DecrBy(ctx, key, int64(delta))
+	}
+	return false, doing, nil
+}
+
+// Confirm 确定业务处理完成
+func (m *RedisExt) Confirm(ctx context.Context, key string) error {
+	_, err := m.Set(ctx, key, done, 0)
+	return err
+}

--- a/cache/redisext/lock_test.go
+++ b/cache/redisext/lock_test.go
@@ -1,0 +1,90 @@
+package redisext
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLock(t *testing.T) {
+	key := "test"
+	value := "76c8c07d15c32fa90dd2b89f141246e8"
+	ctx := context.Background()
+	m := NewRedisExt("test/test", "test")
+	r, err := m.Lock(ctx, key, value, time.Second*1)
+	assert.Nil(t, err)
+	assert.Equal(t, true, r)
+	r1, err := m.Lock(ctx, key, value, time.Second*1)
+	assert.Nil(t, err)
+	assert.Equal(t, false, r1)
+	time.Sleep(time.Second * 1)
+	r2, err := m.Lock(ctx, key, value, time.Second*1)
+	assert.Nil(t, err)
+	assert.Equal(t, true, r2)
+}
+
+func TestLockWithTimeout(t *testing.T) {
+	key := "test"
+	value := "76c8c07d15c32fa90dd2b89f141246e8"
+	ctx := context.Background()
+	m := NewRedisExt("test/test", "test")
+	m.Lock(ctx, key, value, time.Second*5)
+	r, err := m.LockWithTimeout(ctx, key, value, time.Second, time.Second*1)
+	assert.Nil(t, err)
+	assert.Equal(t, false, r)
+}
+
+func TestUnlock(t *testing.T) {
+	key := "test"
+	value := "76c8c07d15c32fa90dd2b89f141246e8"
+	ctx := context.Background()
+	m := NewRedisExt("test/test", "test")
+	r, err := m.Lock(ctx, key, value, time.Second*5)
+	assert.Nil(t, err)
+	assert.Equal(t, true, r)
+	r1, err := m.Unlock(ctx, key, value)
+	assert.Nil(t, err)
+	assert.Equal(t, true, r1)
+	r2, err := m.Lock(ctx, key, value, time.Second*1)
+	assert.Nil(t, err)
+	assert.Equal(t, true, r2)
+}
+
+func TestTryAcquire(t *testing.T) {
+	orderID := "76c8c07d15c32fa90dd2b89f141246e8"
+	ctx := context.Background()
+	m := NewRedisExt("test/test", "test")
+	m.Del(ctx, orderID)
+
+	// Acquired first time
+	canHandle, state, err := m.TryAcquire(ctx, orderID, time.Second*2, time.Hour*24)
+	assert.Nil(t, err)
+	assert.Equal(t, true, canHandle)
+	assert.Equal(t, initState, state)
+
+	// reject cause by other processor
+	canHandle1, state1, err := m.TryAcquire(ctx, orderID, time.Second*3, time.Hour*24)
+	assert.Nil(t, err)
+	assert.Equal(t, false, canHandle1)
+	assert.Equal(t, doing, state1)
+
+	time.Sleep(time.Second * 2)
+
+	// Acquired cause by other processor timeout
+	canHandle2, state2, err := m.TryAcquire(ctx, orderID, time.Second*3, time.Hour*24)
+	assert.Nil(t, err)
+	assert.Equal(t, true, canHandle2)
+	assert.Equal(t, doing, state2)
+
+	// confirm the record
+	err = m.Confirm(ctx, orderID)
+	assert.Nil(t, err)
+
+	// idempotent
+	canHandle3, state3, err := m.TryAcquire(ctx, orderID, time.Second*3, time.Hour*24)
+	assert.Nil(t, err)
+	assert.Equal(t, false, canHandle3)
+	assert.Equal(t, done, state3)
+}

--- a/cache/redisext/lock_test.go
+++ b/cache/redisext/lock_test.go
@@ -59,32 +59,32 @@ func TestTryAcquire(t *testing.T) {
 	m.Del(ctx, orderID)
 
 	// Acquired first time
-	canHandle, state, err := m.TryAcquire(ctx, orderID, time.Second*2, time.Hour*24)
+	canHandle, state, err := m.TryAcquire(ctx, orderID, time.Hour*24, time.Second*2)
 	assert.Nil(t, err)
 	assert.Equal(t, true, canHandle)
-	assert.Equal(t, initState, state)
+	assert.Equal(t, InitState, state)
 
 	// reject cause by other processor
-	canHandle1, state1, err := m.TryAcquire(ctx, orderID, time.Second*3, time.Hour*24)
+	canHandle1, state1, err := m.TryAcquire(ctx, orderID, time.Hour*24, time.Second*3)
 	assert.Nil(t, err)
 	assert.Equal(t, false, canHandle1)
-	assert.Equal(t, doing, state1)
+	assert.Equal(t, Doing, state1)
 
 	time.Sleep(time.Second * 2)
 
 	// Acquired cause by other processor timeout
-	canHandle2, state2, err := m.TryAcquire(ctx, orderID, time.Second*3, time.Hour*24)
+	canHandle2, state2, err := m.TryAcquire(ctx, orderID, time.Hour*24, time.Second*3)
 	assert.Nil(t, err)
 	assert.Equal(t, true, canHandle2)
-	assert.Equal(t, doing, state2)
+	assert.Equal(t, Doing, state2)
 
 	// confirm the record
 	err = m.Confirm(ctx, orderID)
 	assert.Nil(t, err)
 
 	// idempotent
-	canHandle3, state3, err := m.TryAcquire(ctx, orderID, time.Second*3, time.Hour*24)
+	canHandle3, state3, err := m.TryAcquire(ctx, orderID, time.Hour*24, time.Second*3)
 	assert.Nil(t, err)
 	assert.Equal(t, false, canHandle3)
-	assert.Equal(t, done, state3)
+	assert.Equal(t, Done, state3)
 }

--- a/cache/redisext/redisext.go
+++ b/cache/redisext/redisext.go
@@ -3,12 +3,12 @@ package redisext
 import (
 	"context"
 	"fmt"
-	"github.com/shawnfeng/sutil/cache"
 	"time"
 
 	redis2 "github.com/go-redis/redis"
-	"github.com/shawnfeng/sutil/cache/constants"
 	"github.com/opentracing/opentracing-go"
+	"github.com/shawnfeng/sutil/cache"
+	"github.com/shawnfeng/sutil/cache/constants"
 	"github.com/shawnfeng/sutil/cache/redis"
 	"github.com/shawnfeng/sutil/scontext"
 	"github.com/shawnfeng/sutil/slog/slog"

--- a/cache/redisext/script.go
+++ b/cache/redisext/script.go
@@ -1,0 +1,107 @@
+package redisext
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"io"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/shawnfeng/sutil/stime"
+)
+
+type Script struct {
+	src, hash string
+}
+
+// NewScript src: script content
+func NewScript(src string) *Script {
+	h := sha1.New()
+	_, _ = io.WriteString(h, src)
+	return &Script{
+		src:  src,
+		hash: hex.EncodeToString(h.Sum(nil)),
+	}
+}
+
+// Hash return hash of script
+func (s *Script) Hash() string {
+	return s.hash
+}
+
+// ScriptLoad load script to redis server
+func (m *RedisExt) ScriptLoad(ctx context.Context, script *Script) (r string, err error) {
+	command := "redisext.ScriptLoad"
+	span, ctx := opentracing.StartSpanFromContext(ctx, command)
+	st := stime.NewTimeStat()
+	defer func() {
+		span.Finish()
+		statReqDuration(m.namespace, command, st.Millisecond())
+	}()
+	client, err := m.getRedisInstance(ctx)
+	if err == nil {
+		r, err = client.ScriptLoad(ctx, script.src).Result()
+	}
+	statReqErr(m.namespace, command, err)
+	return r, err
+}
+
+// ScriptExists check if script exists in redis server
+func (m *RedisExt) ScriptExists(ctx context.Context, script *Script) (r bool, err error) {
+	command := "redisext.ScriptExists"
+	span, ctx := opentracing.StartSpanFromContext(ctx, command)
+	st := stime.NewTimeStat()
+	defer func() {
+		span.Finish()
+		statReqDuration(m.namespace, command, st.Millisecond())
+	}()
+	client, err := m.getRedisInstance(ctx)
+	if err == nil {
+		result, err := client.ScriptExists(ctx, script.src).Result()
+		if err != nil {
+			return false, err
+		}
+		if len(result) > 0 {
+			r = result[0]
+		}
+	}
+	return r, err
+}
+
+// Eval exec with script
+func (m *RedisExt) Eval(ctx context.Context, script *Script, keys []string, args ...interface{}) (r interface{}, err error) {
+	command := "redisext.Eval"
+	span, ctx := opentracing.StartSpanFromContext(ctx, command)
+	st := stime.NewTimeStat()
+	defer func() {
+		span.Finish()
+		statReqDuration(m.namespace, command, st.Millisecond())
+	}()
+	for i, key := range keys {
+		keys[i] = m.prefixKey(key)
+	}
+	client, err := m.getRedisInstance(ctx)
+	if err == nil {
+		r, err = client.Eval(ctx, script.src, keys, args...).Result()
+	}
+	return r, err
+}
+
+// EvalSha exec with script hash
+func (m *RedisExt) EvalSha(ctx context.Context, script *Script, keys []string, args ...interface{}) (r interface{}, err error) {
+	command := "redisext.EvalSha"
+	span, ctx := opentracing.StartSpanFromContext(ctx, command)
+	st := stime.NewTimeStat()
+	defer func() {
+		span.Finish()
+		statReqDuration(m.namespace, command, st.Millisecond())
+	}()
+	for i, key := range keys {
+		keys[i] = m.prefixKey(key)
+	}
+	client, err := m.getRedisInstance(ctx)
+	if err == nil {
+		r, err = client.EvalSha(ctx, script.hash, keys, args...).Result()
+	}
+	return r, err
+}

--- a/cache/redisext/script.go
+++ b/cache/redisext/script.go
@@ -37,12 +37,12 @@ func (m *RedisExt) ScriptLoad(ctx context.Context, script *Script) (r string, er
 	defer func() {
 		span.Finish()
 		statReqDuration(m.namespace, command, st.Millisecond())
+		statReqErr(m.namespace, command, err)
 	}()
 	client, err := m.getRedisInstance(ctx)
 	if err == nil {
 		r, err = client.ScriptLoad(ctx, script.src).Result()
 	}
-	statReqErr(m.namespace, command, err)
 	return r, err
 }
 
@@ -54,6 +54,7 @@ func (m *RedisExt) ScriptExists(ctx context.Context, script *Script) (r bool, er
 	defer func() {
 		span.Finish()
 		statReqDuration(m.namespace, command, st.Millisecond())
+		statReqErr(m.namespace, command, err)
 	}()
 	client, err := m.getRedisInstance(ctx)
 	if err == nil {
@@ -76,6 +77,7 @@ func (m *RedisExt) Eval(ctx context.Context, script *Script, keys []string, args
 	defer func() {
 		span.Finish()
 		statReqDuration(m.namespace, command, st.Millisecond())
+		statReqErr(m.namespace,command, err)
 	}()
 	for i, key := range keys {
 		keys[i] = m.prefixKey(key)
@@ -95,6 +97,7 @@ func (m *RedisExt) EvalSha(ctx context.Context, script *Script, keys []string, a
 	defer func() {
 		span.Finish()
 		statReqDuration(m.namespace, command, st.Millisecond())
+		statReqErr(m.namespace,command, err)
 	}()
 	for i, key := range keys {
 		keys[i] = m.prefixKey(key)

--- a/cache/redisext/script_test.go
+++ b/cache/redisext/script_test.go
@@ -1,0 +1,37 @@
+package redisext
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewScript(t *testing.T) {
+	script := `
+	if redis.call("GET", KEYS[1]) ~= false then
+			return redis.call("INCRBY", KEYS[1], ARGV[1])
+	end
+	return false`
+	s := NewScript(script)
+	assert.NotNil(t, s)
+	assert.Equal(t, s.Hash(), "0b2cd31fec150908e9e0304c8189bc7168c0b441")
+}
+
+func TestEval(t *testing.T) {
+	script := `
+	if redis.call("GET", KEYS[1]) ~= false then
+			return redis.call("INCRBY", KEYS[1], ARGV[1])
+	end
+	return false`
+	s := NewScript(script)
+	ctx := context.Background()
+	m := NewRedisExt("test/test", "test")
+	m.Set(ctx, "key1", 100, 1*time.Second)
+	r, err := m.Eval(ctx, s, []string{"key1"}, 100)
+	r1, _ := m.Get(ctx, "key1")
+	assert.Nil(t, err)
+	assert.Equal(t, r, int64(200))
+	assert.Equal(t, r1, "200")
+}


### PR DESCRIPTION
1.redisext: support lua script
2.redisext: support global distributed lock
3.redisext: 增加通用幂等操作函数，帮助业务实现幂等操作，如订单重复支付、库存重复扣减等